### PR TITLE
fix: fix lmod PATH env for openmpi-5.0.8

### DIFF
--- a/templates/openmpi-ver-cuda12-gpu.lua
+++ b/templates/openmpi-ver-cuda12-gpu.lua
@@ -1,10 +1,10 @@
 {{ ansible_managed | comment(decoration="-- ") }}
 {{ "system_role:hpc" | comment(decoration="-- ", prefix="", postfix="") }}
 -- This is laregly derived from the system openmpi module file that can be
--- found at /usr/share/modulefiles/mpi/openmpi-x86-64
+-- found at /usr/share/modulefiles/mpi/openmpi-x86-64.
 --
--- This file should be installed in the same directory as the system as:
--- /usr/share/modulefiles/mpi/openmpi-5.0.8-cuda
+-- This file should be installed in the same directory as the above system
+-- openmpi module i.e. /usr/share/modulefiles/mpi/openmpi-5.0.8-cuda-gpu.
 --
 -- This allows it to conflict against other mpi modules already loaded,
 -- so only one MPI environment module can be loaded at any time.
@@ -17,25 +17,37 @@ whatis("If you don't have Infiniband, use '-mca coll ^hcoll' to silence startup 
 whatis("Version: {{ __hpc_openmpi_info.version }}-1")
 
 -- Set the base installation directory
-local base_dir = "/opt/{{ __hpc_openmpi_info.name }}-{{ __hpc_openmpi_info.version }}"
+local ompi_dir = "/opt/{{ __hpc_openmpi_info.name }}-{{ __hpc_openmpi_info.version }}"
+local ucx_dir = "{{ __hpc_ucx_path }}"
+local ucc_dir = "{{ __hpc_ucc_path }}"
+local hcoll_dir = "{{ __hpc_hcoll_path }}"
 
 -- Set up important paths
-prepend_path("PATH", pathJoin(base_dir, "bin"))
-prepend_path("LD_LIBRARY_PATH", pathJoin(base_dir, "lib"))
-prepend_path("LD_LIBRARY_PATH", pathJoin("{{ __hpc_ucx_path }}", "lib"))
-prepend_path("LD_LIBRARY_PATH", pathJoin("{{ __hpc_ucc_path }}", "lib"))
-prepend_path("LD_LIBRARY_PATH", pathJoin("{{ __hpc_hcoll_path }}", "lib"))
-prepend_path("PKG_LIBRARY_PATH", pathJoin(base_dir, "lib/pkgconfig"))
-prepend_path("MANPATH", pathJoin(base_dir, "share/man"))
+prepend_path("PATH", pathJoin(ompi_dir, "bin"))
+prepend_path("PATH", pathJoin(ucx_dir, "bin"))
+prepend_path("PATH", pathJoin(ucc_dir, "bin"))
+prepend_path("PATH", pathJoin(hcoll_dir, "bin"))
+
+prepend_path("LD_LIBRARY_PATH", pathJoin(ompi_dir, "lib"))
+prepend_path("LD_LIBRARY_PATH", pathJoin(ucx_dir, "lib"))
+prepend_path("LD_LIBRARY_PATH", pathJoin(ucc_dir, "lib"))
+prepend_path("LD_LIBRARY_PATH", pathJoin(hcoll_dir, "lib"))
+
+prepend_path("PKG_LIBRARY_PATH", pathJoin(ompi_dir, "lib/pkgconfig"))
+prepend_path("PKG_LIBRARY_PATH", pathJoin(ucx_dir, "lib/pkgconfig"))
+prepend_path("PKG_LIBRARY_PATH", pathJoin(ucc_dir, "lib/pkgconfig"))
+prepend_path("PKG_LIBRARY_PATH", pathJoin(hcoll_dir, "lib/pkgconfig"))
+
+prepend_path("MANPATH", pathJoin(ompi_dir, "share/man"))
 
 -- Set up MPI environment variables. this is not the entire set,
 -- just the important ones for building and running MPI apps.
-setenv("MPI_HOME", base_dir)
-setenv("MPI_BIN", pathJoin(base_dir, "bin"))
-setenv("MPI_SYSCONFIG", pathJoin(base_dir, "etc"))
-setenv("MPI_INCLUDE", pathJoin(base_dir, "include"))
-setenv("MPI_LIB", pathJoin(base_dir, "lib"))
-setenv("MPI_MAN", pathJoin(base_dir, "share/man"))
+setenv("MPI_HOME", ompi_dir)
+setenv("MPI_BIN", pathJoin(ompi_dir, "bin"))
+setenv("MPI_SYSCONFIG", pathJoin(ompi_dir, "etc"))
+setenv("MPI_INCLUDE", pathJoin(ompi_dir, "include"))
+setenv("MPI_LIB", pathJoin(ompi_dir, "lib"))
+setenv("MPI_MAN", pathJoin(ompi_dir, "share/man"))
 setenv("MPI_COMPILER", "{{ __hpc_openmpi_info.name }}-{{ __hpc_openmpi_info.version }}")
 setenv("MPI_SUFFIX", "_{{ __hpc_openmpi_info.name }}-{{ __hpc_openmpi_info.version }}")
 


### PR DESCRIPTION
Attempting to gather UCX debug info fails in the
openmpi-5.0.8-cuda12-gpu environment like so:

$ ml mpi/openmpi-5.0.8-cuda12-gpu
[azureuser@dgc-test-vm ~]$ ucx_info -d
ucx_info: Symbol `ucs_global_opts' has different size in shared object, consider re-linking
Segmentation fault (core dumped)
$

This is caused by running the system ucx_info binary against the HPCX libraries in the LD_LIBRARY_PATH:

[azureuser@dgc-test-vm ~]$ which ucx_info
/usr/bin/ucx_info
[azureuser@dgc-test-vm ~]$ ldd /usr/bin/ucx_info
	linux-vdso.so.1 (0x00007ffd73fbc000)
	libucp.so.0 =>
/opt/hpcx-v2.24.1-gcc-inbox-redhat9-cuda12-x86_64/ucx/hpcx-rebuild/lib/libucp.so.0 (0x00001537cbccd000)
	libuct.so.0 =>
/opt/hpcx-v2.24.1-gcc-inbox-redhat9-cuda12-x86_64/ucx/hpcx-rebuild/lib/libuct.so.0 (0x00001537cbc90000)
	libucs.so.0 =>
/opt/hpcx-v2.24.1-gcc-inbox-redhat9-cuda12-x86_64/ucx/hpcx-rebuild/lib/libucs.so.0 (0x00001537cbaea000)
	libc.so.6 => /lib64/libc.so.6 (0x00001537cb800000)
	libm.so.6 => /lib64/libm.so.6 (0x00001537cb725000)
	libucm.so.0 =>
/opt/hpcx-v2.24.1-gcc-inbox-redhat9-cuda12-x86_64/ucx/hpcx-rebuild/lib/libucm.so.0 (0x00001537cbac2000)
	libz.so.1 => /lib64/libz.so.1 (0x00001537cbaa8000)
	/lib64/ld-linux-x86-64.so.2 (0x00001537cbdc8000)

Running the ucx_info binary from the ...ucx/hpcx-rebuild/bin/ directory orks correctly, as it was compiled against the HPCX libraries found via the LD_LIBARY_PATH.

Update all the path environments so the correct HPCX directories are searched first, hence finding the correct binaries fbraries and package configs for the selected openmpi environment.

Enhancement:

Reason:

Result:

Issue Tracker Tickets (Jira or BZ if any):
