### PR TITLE
feat: add Intel oneAPI MKL standalone installation and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,20 @@ Default: `true`
 
 Type: `bool`
 
+### hpc_install_intel_mkl
+
+Whether to install Intel oneAPI Math Kernel Library (MKL).
+
+Intel MKL provides optimized mathematical functions for scientific computing, data analytics, and machine learning workloads. The role installs the development package (`intel-oneapi-mkl-devel`) including headers and libraries for building applications with MKL.
+
+Note that a standalone MKL version is installed. The role also configures the Intel oneAPI repository and installs the latest MKL version. For more information, see <https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html>.
+
+**License**: By enabling this variable and installing Intel MKL, you accept the Intel End User License Agreement (EULA). The license is available at <https://www.intel.com/content/www/us/en/developer/articles/license/end-user-license-agreement.html#inpage-nav-2> and in the installed package at `/opt/intel/oneapi/mkl/latest/share/doc/mkl/licensing/license.txt`.
+
+Default: `true`
+
+Type: `bool`
+
 ## Variables for Configuring How Role Reboots Managed Nodes
 
 ### hpc_reboot_ok

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,6 +36,7 @@ hpc_tuning: true
 hpc_sku_customisation: true
 hpc_install_diagnostics: true
 hpc_install_kvp_client: true
+hpc_install_intel_mkl: true
 
 hpc_update_kernel: true
 hpc_update_all_packages: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,6 +52,7 @@
     - "{{ __hpc_rhel_epel_repo }}"
     - "{{ __hpc_nvidia_cuda_repo }}"
     - "{{ __hpc_microsoft_prod_repo }}"
+    - "{{ __hpc_intel_oneapi_repo }}"
 
 # package dkms is required from this repo
 - name: Install EPEL release package
@@ -70,6 +71,7 @@
   loop:
     - "{{ __hpc_nvidia_cuda_repo }}"
     - "{{ __hpc_microsoft_prod_repo }}"
+    - "{{ __hpc_intel_oneapi_repo }}"
 
 - name: Ensure EPEL repository is enabled
   include_tasks: tasks/enable_epel.yml
@@ -1685,6 +1687,25 @@
           loop:
             - "{{ __hpc_diags_patch_file.path }}"
             - "{{ __hpc_pkg_extracted.path }}"
+
+# Installing Intel MKL implies acceptance of the Intel End User License Agreement (EULA)
+# License: https://www.intel.com/content/www/us/en/developer/articles/license/end-user-license-agreement.html
+# Installed license file: /opt/intel/oneapi/mkl/latest/share/doc/mkl/licensing/license.txt
+- name: Install Intel oneAPI Math Kernel Library
+  when: hpc_install_intel_mkl
+  block:
+    - name: Install Intel MKL development package (standalone MKL version)
+      package:
+        name: intel-oneapi-mkl-devel
+        state: present
+
+    - name: Install Intel MKL test script
+      template:
+        src: test-intel-mkl.sh.j2
+        dest: "{{ __hpc_azure_tests_dir }}/test-intel-mkl.sh"
+        owner: root
+        group: root
+        mode: '0755'
 
 - name: Clean dnf cache
   command: dnf clean all

--- a/templates/test-intel-mkl.sh.j2
+++ b/templates/test-intel-mkl.sh.j2
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+# These are templates, not actual shell scripts, so tell shellcheck to
+# ignore the templated parts
+# shellcheck disable=all
+{{ ansible_managed | comment }}
+{{ "system_role:hpc" | comment(prefix="", postfix="") }}
+# shellcheck enable=all
+# SPDX-License-Identifier: MIT
+#
+# Intel oneAPI Math Kernel Library Test Script
+# Usage: ./test-intel-mkl.sh [-v]
+#
+
+set -euo pipefail
+
+# Default configuration
+VERBOSE=0
+
+# Test counter
+PASSED=0
+
+# ------------------------------------------------------------------------------
+# Helper Functions
+# ------------------------------------------------------------------------------
+
+pass() {
+    echo "[PASS] $1"
+    PASSED=$((PASSED + 1))
+}
+
+fail() {
+    echo "[FAIL] $1"
+    exit 1
+}
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Test Intel oneAPI Math Kernel Library installation and functionality
+
+OPTIONS:
+    -v              Verbose mode
+    -h              Show this help message
+
+EXAMPLES:
+    # Run with default settings
+    sudo ./test-intel-mkl.sh
+
+    # Run with verbose output
+    sudo ./test-intel-mkl.sh -v
+
+EOF
+    exit 0
+}
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+}
+
+verbose_log() {
+    if [[ $VERBOSE -eq 1 ]]; then
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+    fi
+}
+
+# ------------------------------------------------------------------------------
+# Parse Arguments
+# ------------------------------------------------------------------------------
+
+while getopts "vh" opt; do
+    case $opt in
+        v)
+            VERBOSE=1
+            ;;
+        h)
+            usage
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+# ------------------------------------------------------------------------------
+# Test: Intel oneAPI Repository Configuration
+# ------------------------------------------------------------------------------
+
+test_oneapi_repo() {
+    log "Test: Intel oneAPI repository configuration..."
+    echo ""
+
+    # Check if oneAPI repository is configured
+    echo "Checking: oneAPI repository is configured"
+    if ! dnf repolist --enabled | grep -qi oneAPI; then
+        fail "Intel oneAPI repository is not enabled"
+    fi
+    pass "Intel oneAPI repository is configured"
+
+    if [[ $VERBOSE -eq 1 ]]; then
+        verbose_log "Repository details:"
+        dnf repoinfo oneAPI 2>/dev/null || true
+    fi
+
+    echo ""
+}
+
+# ------------------------------------------------------------------------------
+# Test: Intel MKL Package Installation
+# ------------------------------------------------------------------------------
+
+test_mkl_package() {
+    log "Test: Intel MKL package installation..."
+    echo ""
+
+    # Check if intel-oneapi-mkl-devel package is installed
+    echo "Checking: intel-oneapi-mkl-devel package is installed"
+    if ! rpm -q intel-oneapi-mkl-devel >/dev/null 2>&1; then
+        fail "intel-oneapi-mkl-devel package is not installed"
+    fi
+    pass "intel-oneapi-mkl-devel package is installed"
+
+    if [[ $VERBOSE -eq 1 ]]; then
+        verbose_log "Package: $(rpm -q intel-oneapi-mkl-devel)"
+    fi
+
+    echo ""
+}
+
+# ------------------------------------------------------------------------------
+# Test: MKL Installation Directory
+# ------------------------------------------------------------------------------
+
+test_mkl_installation() {
+    log "Test: MKL installation directory and files..."
+    echo ""
+
+    # Check if MKL installation directory exists
+    echo "Checking: MKL installation directory exists"
+    if [[ ! -d /opt/intel/oneapi/mkl ]]; then
+        fail "MKL installation directory /opt/intel/oneapi/mkl does not exist"
+    fi
+    pass "MKL installation directory exists"
+
+    # Check for MKL libraries
+    echo "Checking: MKL libraries are present"
+    local mkl_lib_dir
+    mkl_lib_dir=$(find /opt/intel/oneapi/mkl -type d \( -name "lib" -o -name "lib64" \) | head -1)
+    if [[ -z "$mkl_lib_dir" ]] || [[ ! -d "$mkl_lib_dir" ]]; then
+        fail "MKL library directory not found"
+    fi
+
+    if ! ls "$mkl_lib_dir"/libmkl_core.* >/dev/null 2>&1; then
+        fail "MKL core libraries not found in $mkl_lib_dir"
+    fi
+    pass "MKL libraries are present"
+
+    # Check for MKL headers
+    echo "Checking: MKL header files are present"
+    local mkl_include_dir
+    mkl_include_dir=$(find /opt/intel/oneapi/mkl -type d -name "include" | head -1)
+    if [[ -z "$mkl_include_dir" ]] || [[ ! -d "$mkl_include_dir" ]]; then
+        fail "MKL include directory not found"
+    fi
+
+    if [[ ! -f "$mkl_include_dir/mkl.h" ]]; then
+        fail "MKL header file mkl.h not found in $mkl_include_dir"
+    fi
+    pass "MKL header files are present"
+
+    if [[ $VERBOSE -eq 1 ]]; then
+        verbose_log "MKL installation details:"
+        verbose_log "Library directory: $mkl_lib_dir"
+        verbose_log "Include directory: $mkl_include_dir"
+        verbose_log "Core libraries:"
+        ls -lh "$mkl_lib_dir"/libmkl_core.* 2>/dev/null || true
+    fi
+
+    echo ""
+}
+
+# ------------------------------------------------------------------------------
+# Test: MKL Environment Variables
+# ------------------------------------------------------------------------------
+
+test_mkl_environment() {
+    log "Test: MKL environment setup..."
+    echo ""
+
+    # Check for setvars.sh script
+    echo "Checking: MKL environment setup script exists"
+    if [[ ! -f /opt/intel/oneapi/setvars.sh ]]; then
+        fail "Intel oneAPI environment setup script not found at /opt/intel/oneapi/setvars.sh"
+    fi
+    pass "MKL environment setup script exists"
+}
+
+# ------------------------------------------------------------------------------
+# Test: MKL Compile and Link Test
+# ------------------------------------------------------------------------------
+
+test_mkl_compile() {
+    log "Test: MKL compile and link test..."
+    echo ""
+
+    # Create temporary directory for test
+    local test_dir
+    test_dir=$(mktemp -d)
+
+    # Create simple MKL test program
+    cat > "$test_dir/mkl_test.c" <<'EOF'
+#include <stdio.h>
+#include <mkl.h>
+
+int main() {
+    MKLVersion version;
+    mkl_get_version(&version);
+    printf("Intel MKL %d.%d.%d\n", version.MajorVersion, version.MinorVersion, version.UpdateVersion);
+    return 0;
+}
+EOF
+
+    # Source oneAPI environment and compile
+    echo "Checking: MKL test program compiles and links"
+
+    # Source setvars.sh only if MKLROOT is not already set
+    if [[ -z "${MKLROOT:-}" ]]; then
+        # shellcheck disable=SC1091
+        source /opt/intel/oneapi/setvars.sh >/dev/null 2>&1 || true
+    fi
+
+    # Verify MKLROOT is set
+    if [[ -z "${MKLROOT:-}" ]]; then
+        fail "MKLROOT not set - Intel oneAPI environment not loaded"
+    fi
+
+    local compile_output
+    local compile_ret=0
+    compile_output=$(gcc -o "$test_dir/mkl_test" "$test_dir/mkl_test.c" \
+        -lmkl_intel_lp64 -lmkl_sequential -lmkl_core \
+        -lpthread -lm -ldl 2>&1) || compile_ret=$?
+
+    if [[ $compile_ret -ne 0 ]]; then
+        fail "Failed to compile MKL test program: $compile_output"
+    fi
+    pass "MKL test program compiled successfully"
+
+    # Run the test program
+    echo "Checking: MKL test program executes"
+    local run_output
+    local run_ret=0
+    run_output=$("$test_dir/mkl_test" 2>&1) || run_ret=$?
+
+    if [[ $run_ret -ne 0 ]]; then
+        fail "Failed to run MKL test program: $run_output"
+    fi
+    pass "MKL test program executed successfully"
+
+    if [[ $VERBOSE -eq 1 ]]; then
+        verbose_log "MKL version: $run_output"
+    fi
+
+    # Clean up temporary directory
+    rm -rf "$test_dir"
+
+    echo ""
+}
+
+# ------------------------------------------------------------------------------
+# Main
+# ------------------------------------------------------------------------------
+
+main() {
+    log "=========================================================="
+    log "Intel oneAPI Math Kernel Library Test"
+    log "=========================================================="
+    echo ""
+
+    # Repository configuration check
+    test_oneapi_repo
+
+    # Package installation check
+    test_mkl_package
+
+    # Installation directory and files check
+    test_mkl_installation
+
+    # Environment setup check
+    test_mkl_environment
+
+    # Compile and link test
+    test_mkl_compile
+
+    # If we get here, all tests passed
+    echo ""
+    log "=========================================================="
+    log "All tests passed ($PASSED)"
+    log "=========================================================="
+    echo ""
+    exit 0
+}
+
+main "$@"

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -24,6 +24,7 @@
     hpc_tuning: false
     hpc_sku_customisation: false
     hpc_install_kvp_client: false
+    hpc_install_intel_mkl: false
   tasks:
     - name: Skip unsupported architectures
       include_tasks: tasks/skip_unsupported_archs.yml

--- a/tests/tests_include_vars_from_parent.yml
+++ b/tests/tests_include_vars_from_parent.yml
@@ -69,6 +69,7 @@
             hpc_tuning: false
             hpc_sku_customisation: false
             hpc_install_kvp_client: false
+            hpc_install_intel_mkl: false
 
         - name: Cleanup
           file:

--- a/tests/tests_skip_toolkit.yml
+++ b/tests/tests_skip_toolkit.yml
@@ -28,6 +28,7 @@
     hpc_tuning: false
     hpc_sku_customisation: false
     hpc_install_kvp_client: false
+    hpc_install_intel_mkl: false
   tags:
     - tests::reboot
   tasks:

--- a/vars/RedHat_9.yml
+++ b/vars/RedHat_9.yml
@@ -21,6 +21,12 @@ __hpc_rhui_azure_rhel_9_eus_repo:
   description: Microsoft Azure RPMs for Red Hat Enterprise Linux 9 EUS
   key: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-microsoft-azure-release
   baseurl: https://rhui4-1.microsoft.com/pulp/repos/unprotected/microsoft-azure-rhel9-eus
+# intel-oneapi-mkl-devel-2025.3.1-8.x86_64
+__hpc_intel_oneapi_repo:
+  name: oneAPI
+  description: Intel(R) oneAPI repository
+  key: https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+  baseurl: https://yum.repos.intel.com/oneapi
 
 # Vars related to RPMs
 __hpc_nvidia_driver_stream: 580-dkms


### PR DESCRIPTION
Enhancement:
- install intel-oneapi-mkl-devel via Intel oneAPI repository
- use standalone MKL to avoid full toolkit dependencies (e.g. Intel MPI)
- add validation script for installation and runtime checks
- reference: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html

Reason:
Add intel-oneapi-mkl-devel package and test script

Result:
` rpm -qa | grep -i intel-oneapi-mkl-devel
intel-oneapi-mkl-devel-2025.3-2025.3.1-8.x86_64
intel-oneapi-mkl-devel-2025.3.1-8.x86_64

pwd
/opt/intel/oneapi

ls
common  compiler  licensing  mkl  modulefiles-setup.sh  setvars.sh  support.txt  tbb  tcm  umf

 #bash /opt/hpc/azure/tests/test-intel-mkl.sh 
==========================================================
[2026-04-07 12:43:40] Intel oneAPI Math Kernel Library Test
[2026-04-07 12:43:40] ==========================================================

[2026-04-07 12:43:40] Test: Intel oneAPI repository configuration...

Checking: oneAPI repository is configured
[PASS] Intel oneAPI repository is configured

[2026-04-07 12:43:40] Test: Intel MKL package installation...

Checking: intel-oneapi-mkl-devel package is installed
[PASS] intel-oneapi-mkl-devel package is installed

[2026-04-07 12:43:40] Test: MKL installation directory and files...

Checking: MKL installation directory exists
[PASS] MKL installation directory exists
Checking: MKL libraries are present
[PASS] MKL libraries are present
Checking: MKL header files are present
[PASS] MKL header files are present

[2026-04-07 12:43:40] Test: MKL environment setup...

Checking: MKL environment setup script exists
[PASS] MKL environment setup script exists
[2026-04-07 12:43:40] Test: MKL compile and link test...

Checking: MKL test program compiles and links
[PASS] MKL test program compiled successfully
Checking: MKL test program executes
[PASS] MKL test program executed successfully


[2026-04-07 12:43:41] ==========================================================
[2026-04-07 12:43:41] All tests passed (8)
[2026-04-07 12:43:41] ==========================================================



`

Issue Tracker Tickets (Jira or BZ if any):
JIRA: RHELHPC-108,RHELHPC-121

## Summary by Sourcery

Add optional installation and validation of Intel oneAPI Math Kernel Library via the Intel oneAPI repository.

New Features:
- Introduce a configurable option to install the Intel oneAPI MKL development package using the Intel oneAPI repository.
- Provide a validation script to verify Intel oneAPI MKL installation, libraries, headers, and environment setup.

Enhancements:
- Extend repository configuration to include the Intel oneAPI repository on RHEL 9 systems.
- Document the new MKL installation toggle and its behavior in the role README.

Tests:
- Update Ansible test playbooks to cover scenarios where Intel MKL installation is disabled.