### PR TITLE
ci: update header for run_role_with_clear_facts [citest_skip]

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -20,7 +20,6 @@ exclude_paths:
   - .github/
   - .markdownlint.yaml
   - examples/roles/
-  - .collection/
 mock_roles:
   - linux-system-roles.hpc
 supported_ansible_also:


### PR DESCRIPTION
Update header for run_role_with_clear_facts to indicate not editable
and clarify what it does

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Documentation:
- Clarify the description of the run_role_with_clear_facts behavior in the Ansible lint configuration header comment.