### PR TITLE
fix: ensure selinux facts are gathered

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -11,6 +11,7 @@ __hpc_required_facts:
   - os_family
   # required for ansible_facts["processor_nproc"]
   - processor
+  - selinux
 # the subsets of ansible_facts that need to be gathered in case any of the
 # facts in required_facts is missing; see the documentation of
 # the 'gather_subset' parameter of the 'setup' module


### PR DESCRIPTION
Ensure selinux facts are gathered

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Bug Fixes:
- Include SELinux in the set of required Ansible facts to avoid missing fact issues during playbook execution.