### PR TITLE
feat: avoid degraded systemd state on hosts without GPUs

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -501,6 +501,15 @@
           RestartSec=5s
       notify: Reload systemd
 
+    - name: Create systemd drop-in for nvidia-persistenced.service to only start if the nvidia kernel module is loaded
+      template:
+        src: 50-skip-when-nvidia-kernel-module-not-loaded.conf.j2
+        dest: /etc/systemd/system/nvidia-persistenced.service.d/50-skip-when-nvidia-kernel-module-not-loaded.conf
+        owner: root
+        group: root
+        mode: '0644'
+      notify: Reload systemd
+
     - name: Enable nvidia-persistenced.service
       service:
         name: nvidia-persistenced.service
@@ -570,6 +579,23 @@
       register: __hpc_nvidia_fabric_manager_packages_install
       until: __hpc_nvidia_fabric_manager_packages_install is success
 
+    - name: Ensure nvidia-fabricmanager drop-in directory exists
+      file:
+        path: /etc/systemd/system/nvidia-fabricmanager.service.d
+        state: directory
+        owner: root
+        group: root
+        mode: '0755'
+
+    - name: Create systemd drop-in for nvidia-fabricmanager.service to only start if NVswitch devices are detected
+      template:
+        src: 50-skip-when-no-nvswitch-devices-present.conf.j2
+        dest: /etc/systemd/system/nvidia-fabricmanager.service.d/50-skip-when-no-nvswitch-devices-present.conf
+        owner: root
+        group: root
+        mode: '0644'
+      notify: Reload systemd
+
     - name: Ensure that Fabric Manager service is enabled
       service:
         name: nvidia-fabricmanager
@@ -586,6 +612,23 @@
         state: present
         use: "{{ (__hpc_server_is_ostree | d(false)) |
           ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
+
+    - name: Ensure nvidia-imex drop-in directory exists
+      file:
+        path: /etc/systemd/system/nvidia-imex.service.d
+        state: directory
+        owner: root
+        group: root
+        mode: '0755'
+
+    - name: Create systemd drop-in for nvidia-imex.service to only start if the nvidia kernel module is loaded
+      template:
+        src: 50-skip-when-nvidia-kernel-module-not-loaded.conf.j2
+        dest: /etc/systemd/system/nvidia-imex.service.d/50-skip-when-nvidia-kernel-module-not-loaded.conf
+        owner: root
+        group: root
+        mode: '0644'
+      notify: Reload systemd
 
     - name: Enable NVIDIA IMEX service
       systemd:
@@ -885,6 +928,23 @@
             state: absent
           changed_when: false
 
+        - name: Ensure gdrcopy drop-in directory exists
+          file:
+            path: /etc/systemd/system/gdrcopy.service.d
+            state: directory
+            owner: root
+            group: root
+            mode: '0755'
+
+        - name: Create systemd drop-in for gdrcopy.service to only start if the gdrcopy kernel module is loaded
+          template:
+            src: 50-skip-when-gdrdrv-kernel-module-not-loaded.conf.j2
+            dest: /etc/systemd/system/gdrcopy.service.d/50-skip-when-gdrdrv-kernel-module-not-loaded.conf
+            owner: root
+            group: root
+            mode: '0644'
+          notify: Reload systemd
+
     - name: Get stat of hpcx-rebuild path
       stat:
         path: "{{ __hpc_hpcx_rebuild_path }}"
@@ -1071,6 +1131,23 @@
           ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
       register: __hpc_nvidia_container_toolkit_install
       until: __hpc_nvidia_container_toolkit_install is success
+
+    - name: Ensure nvidia-cdi-refresh drop-in directory exists
+      file:
+        path: /etc/systemd/system/nvidia-cdi-refresh.service.d
+        state: directory
+        owner: root
+        group: root
+        mode: '0755'
+
+    - name: Create systemd drop-in for nvidia-cdi-refresh.service to only start if the nvidia kernel module is loaded
+      template:
+        src: 50-skip-when-nvidia-kernel-module-not-loaded.conf.j2
+        dest: /etc/systemd/system/nvidia-cdi-refresh.service.d/50-skip-when-nvidia-kernel-module-not-loaded.conf
+        owner: root
+        group: root
+        mode: '0644'
+      notify: Reload systemd
 
     - name: Check if NVIDIA runtime is configured in Docker daemon
       find:

--- a/templates/50-skip-when-gdrdrv-kernel-module-not-loaded.conf.j2
+++ b/templates/50-skip-when-gdrdrv-kernel-module-not-loaded.conf.j2
@@ -1,0 +1,10 @@
+{{ ansible_managed | comment }}
+{{ "system_role:hpc" | comment(prefix="", postfix="") }}
+
+[Unit]
+# The ConditionKernelModuleLoaded directive was added in systemd version 258.
+# The RHEL version this aims to support has an older systemd version,
+# so work around it by using ConditionPathExists with a well-known
+# path in /dev created by the relevant kernel module on load.
+#ConditionKernelModuleLoaded=gdrdrv
+ConditionPathExists=/dev/gdrdrv

--- a/templates/50-skip-when-no-nvswitch-devices-present.conf.j2
+++ b/templates/50-skip-when-no-nvswitch-devices-present.conf.j2
@@ -1,0 +1,5 @@
+{{ ansible_managed | comment }}
+{{ "system_role:hpc" | comment(prefix="", postfix="") }}
+
+[Unit]
+ConditionPathExists=/dev/nvidia-nvswitch0

--- a/templates/50-skip-when-nvidia-kernel-module-not-loaded.conf.j2
+++ b/templates/50-skip-when-nvidia-kernel-module-not-loaded.conf.j2
@@ -1,0 +1,10 @@
+{{ ansible_managed | comment }}
+{{ "system_role:hpc" | comment(prefix="", postfix="") }}
+
+[Unit]
+# The ConditionKernelModuleLoaded directive was added in systemd version 258.
+# The RHEL version this aims to support has an older systemd version,
+# so work around it by using ConditionPathExists with a well-known
+# path in /dev created by the relevant kernel module on load.
+#ConditionKernelModuleLoaded=nvidia
+ConditionPathExists=/dev/nvidiactl


### PR DESCRIPTION
Enhancement: avoid `degraded` systemd state on hosts without GPUs

Reason:

On hosts with no NVIDIA GPU devices, various systemd services will fail to start and result in `degraded` systemd state:

```bash
$ systemctl is-system-running
degraded

$ systemctl --failed
  UNIT                         LOAD   ACTIVE SUB    DESCRIPTION
● gdrcopy.service              loaded failed failed GDRCopy service
● nvidia-cdi-refresh.service   loaded failed failed Refresh NVIDIA CDI specification file
● nvidia-fabricmanager.service loaded failed failed NVIDIA fabric manager service
● nvidia-imex.service          loaded failed failed NVIDIA IMEX service
● nvidia-persistenced.service  loaded failed failed NVIDIA Persistence Daemon

LOAD   = Reflects whether the unit definition was properly loaded.
ACTIVE = The high-level unit activation state, i.e. generalization of SUB.
SUB    = The low-level unit activation state, values depend on unit type.
5 loaded units listed.
```

This could trip various system-level health checks or external monitoring into considering the host to be broken, when in fact the services are not started simply due to the required HW not being present.

Additionally, the `nvidia-fabricmanager.service` will also fail to start when the attached GPU devices lack the actual NVSwitch fabric hardware:

```bash
$ systemctl is-system-running
degraded

$ systemctl --failed
  UNIT                         LOAD   ACTIVE SUB    DESCRIPTION
● nvidia-fabricmanager.service loaded failed failed NVIDIA fabric manager service
    
LOAD   = Reflects whether the unit definition was properly loaded.
ACTIVE = The high-level unit activation state, i.e. generalization of SUB.
SUB    = The low-level unit activation state, values depend on unit type.
1 loaded units listed.
```

This PR adds systemd drop-in files to the relevant services' configuration, resulting in them being successfully skipped in case the `nvidia` (or `gdrdrv` in case of `gdrcopy.service`) kernel driver is not loaded. The `nvidia-fabricmanager.service` is gated on existence of at least one NVSwitch device node, which indicates presence of the required fabric hardware.

Result: The systemd state should no longer be `degraded` due to NVIDIA services on hosts without GPUs

Issue Tracker Tickets (Jira or BZ if any): https://redhat.atlassian.net/browse/RHELHPC-154

## Summary by Sourcery

Add systemd drop-ins so NVIDIA-related services are only started when their corresponding kernel drivers or hardware are present, preventing degraded system state on hosts without GPUs or NVSwitch.

New Features:
- Gate nvidia-persistenced, nvidia-imex, and nvidia-cdi-refresh services on the presence of the NVIDIA kernel module via systemd drop-in units.
- Gate nvidia-fabricmanager service on the presence of NVSwitch device nodes via a systemd drop-in unit.
- Gate gdrcopy service on the presence of the gdrdrv device node via a systemd drop-in unit.

Enhancements:
- Introduce reusable systemd drop-in templates that use device-node existence checks as a compatibility workaround for older systemd versions lacking ConditionKernelModuleLoaded.