### PR TITLE
fix: add verbosity-based no_log to facts modules

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -326,7 +326,7 @@
 
 - name: Get package facts
   package_facts:
-  no_log: true
+  no_log: "{{ ansible_verbosity < 2 }}"
 
 # This is required for dkms to build NVidia drivers for all kernels
 - name: Install kernel-devel and kernel-headers packages for all kernels


### PR DESCRIPTION
Feature: Add verbosity-based no_log to facts modules.

Reason: Facts modules like package_facts produce verbose output that clutters logs during normal operation, making it difficult to review playbook execution.

Result:
  - package_facts now uses no_log: "{{ ansible_verbosity < 2 }}", hiding verbose output unless -vv or higher verbosity is specified
  - Users can still see full facts output when debugging by running with increased verbosity
  - No impact on normal operation, just cleaner logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent unnecessary suppression of package_facts output by only hiding it when Ansible verbosity is below -vv.