### PR TITLE
fix: Use verbosity level 3 for no_log

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -326,7 +326,7 @@
 
 - name: Get package facts
   package_facts:
-  no_log: "{{ ansible_verbosity < 2 }}"
+  no_log: "{{ ansible_verbosity < 3 }}"
 
 # This is required for dkms to build NVidia drivers for all kernels
 - name: Install kernel-devel and kernel-headers packages for all kernels


### PR DESCRIPTION
Use `ansible_verbosity < 3` instead of `< 2` to show output with `-vvv` or higher.

## Summary by Sourcery

Bug Fixes:
- Correct the no_log condition for the package facts task so its output is only shown when running Ansible with -vvv or higher verbosity.