### PR TITLE
test: Add MPI library test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,16 @@ Default: `true`
 
 Type: `bool`
 
+### hpc_install_mpi_tests
+
+Whether to download and install the OSU Micro-Benchmarks (OMB) for MPI performance testing.
+
+OMB provides a suite of benchmarks for measuring MPI latency, bandwidth, and collective operation performance. The benchmarks are installed as source to `/opt/hpc/azure/tests/osu-micro-benchmarks/` along with a test script that builds and runs the benchmarks using the installed MPI libraries.
+
+Default: `true`
+
+Type: `bool`
+
 ### hpc_install_nvidia_container_toolkit
 
 Whether to install and configure NVIDIA Container Toolkit.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,7 @@ hpc_install_system_openmpi: true
 hpc_build_mpi_w_nvidia_gpu_support: "{{ hpc_build_openmpi_w_nvidia_gpu_support | d(true) }}"
 hpc_install_mvapich: true
 hpc_install_mpifileutils: true
+hpc_install_mpi_tests: true
 hpc_install_moneo: true
 hpc_install_nvidia_container_toolkit: true
 hpc_install_docker: "{{ hpc_install_nvidia_container_toolkit }}"

--- a/tasks/mpi.yml
+++ b/tasks/mpi.yml
@@ -402,6 +402,55 @@
         group: root
         mode: '0755'
 
+- name: Download and install OSU Micro-Benchmarks
+  when: hpc_install_mpi_tests
+  block:
+    - name: Get stat of OMB source directory
+      stat:
+        path: "{{ __hpc_azure_omb_dir }}/configure"
+      register: __hpc_omb_path_stat
+
+    - name: Download and extract OMB
+      when: not __hpc_omb_path_stat.stat.exists
+      block:
+        - name: Download OMB
+          include_tasks: tasks/download_extract_package.yml
+          vars:
+            __hpc_pkg_info: "{{ __hpc_omb_info }}"
+
+        - name: Copy OMB source to tests directory
+          copy:
+            src: "{{ __hpc_pkg_extracted.path }}/"
+            remote_src: true
+            dest: "{{ __hpc_azure_omb_dir }}"
+            owner: root
+            group: root
+            mode: '0755'
+
+        # OMB doesn't support out-of-tree builds, so users need write
+        # access to the source directories for in-tree configure and make.
+        # Capital X applies +x only to directories and files that already
+        # have owner execute set (e.g. scripts like configure).
+        - name: Fix OMB permissions for non-root users
+          file:
+            path: "{{ __hpc_azure_omb_dir }}"
+            mode: "u+rwX,go+rwX"
+            recurse: true
+
+        - name: Remove extracted tarball
+          file:
+            path: "{{ __hpc_pkg_extracted.path }}"
+            state: absent
+          changed_when: false
+
+    - name: Install MPI test script
+      template:
+        src: test-mpi-omb.sh.j2
+        dest: "{{ __hpc_azure_tests_dir }}/test-mpi-omb.sh"
+        owner: root
+        group: root
+        mode: '0755'
+
 - name: Download, build, and install mpifileutils
   when: hpc_install_mpifileutils
   block:

--- a/tasks/mpi.yml
+++ b/tasks/mpi.yml
@@ -72,7 +72,8 @@
     - name: Install build dependencies
       package:
         name: >-
-          {{ __hpc_pmix_build_dependencies
+          {{ __hpc_mpi_packages
+          + __hpc_pmix_build_dependencies
           + __hpc_gdrcopy_build_dependencies
           + __hpc_openmpi_build_dependencies }}
         state: present

--- a/templates/test-mpi-omb.sh.j2
+++ b/templates/test-mpi-omb.sh.j2
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# shellcheck disable=all
+{{ ansible_managed | comment }}
+{{ "system_role:hpc" | comment(prefix="", postfix="") }}
+# SPDX-License-Identifier: MIT
+#
+# Test Script: MPI implementation validation using OSU Micro-Benchmarks
+#
+# Builds and runs OMB against each installed MPI library to verify that the
+# MPI stack is functional. Currently limited to single-host tests only.
+#
+
+set -euo pipefail
+
+VERBOSE=0
+PASSED=0
+
+OMB_SRC="{{ __hpc_azure_omb_dir }}"
+
+# ------------------------------------------------------------------------------
+# Helper Functions
+# ------------------------------------------------------------------------------
+
+pass() {
+    echo "[PASS] $1"
+    PASSED=$((PASSED + 1))
+}
+
+fail() {
+    echo "[FAIL] $1"
+    exit 1
+}
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+}
+
+verbose_log() {
+    if [[ $VERBOSE -eq 1 ]]; then
+        echo "[$(date "+%Y-%m-%d %H:%M:%S")] $*"
+    fi
+}
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+Build and run OSU Micro-Benchmarks against all installed MPI libraries
+
+OPTIONS:
+  -v    Verbose output
+  -h    Show this help message
+
+EOF
+    exit 0
+}
+
+# ------------------------------------------------------------------------------
+# Parse Arguments
+# ------------------------------------------------------------------------------
+
+while getopts "vh" opt; do
+    case $opt in
+        v) VERBOSE=1 ;;
+        h) usage ;;
+        *) usage ;;
+    esac
+done
+
+# ------------------------------------------------------------------------------
+# Build OMB for a given MPI module
+# ------------------------------------------------------------------------------
+
+build_omb() {
+    local module_name="$1"
+    local build_log
+    build_log=$(mktemp /tmp/omb-build-XXXXXX.log)
+
+    log "Building OMB for $module_name in $OMB_SRC"
+
+    clean_omb
+
+    if ! (cd "$OMB_SRC" && ./configure CC=mpicc CXX=mpicxx) >"$build_log" 2>&1; then
+        cat "$build_log"
+        rm -f "$build_log"
+        fail "OMB configure failed for $module_name"
+    fi
+    verbose_log "Configure completed for $module_name"
+
+    if ! make -C "$OMB_SRC" -j "$(nproc)" >>"$build_log" 2>&1; then
+        cat "$build_log"
+        rm -f "$build_log"
+        fail "OMB build failed for $module_name"
+    fi
+    rm -f "$build_log"
+    pass "$module_name: OMB build succeeded"
+}
+
+clean_omb() {
+    if [[ -f "$OMB_SRC/Makefile" ]]; then
+        make -C "$OMB_SRC" distclean >/dev/null 2>&1 || true
+    fi
+}
+
+# ------------------------------------------------------------------------------
+# Run a single OMB test binary
+# ------------------------------------------------------------------------------
+
+run_omb_test() {
+    local module_name="$1"
+    local test_binary="$2"
+    local np="$3"
+    local test_name
+    test_name=$(basename "$test_binary")
+
+    if [[ ! -x "$test_binary" ]]; then
+        fail "$module_name: $test_name not found"
+    fi
+
+    local output
+    local rc=0
+    output=$(mpiexec -np "$np" "$test_binary" 2>&1) || rc=$?
+
+    if [[ $rc -ne 0 ]]; then
+        echo "$output" | sed 's/^/    /'
+        fail "$module_name: $test_name (exit code $rc)"
+    fi
+
+    pass "$module_name: $test_name"
+    if [[ $VERBOSE -eq 1 ]]; then
+        echo "$output" | sed 's/^/    /'
+    fi
+}
+
+# ------------------------------------------------------------------------------
+# Run an OMB launcher (omb_pt2pt or omb_coll)
+# ------------------------------------------------------------------------------
+
+run_omb_launcher() {
+    local module_name="$1"
+    local launcher="$2"
+    local np="$3"
+    shift 3
+    local launcher_name
+    launcher_name=$(basename "$launcher")
+    local output_log
+    output_log=$(mktemp /tmp/omb-${launcher_name}-XXXXXX.log)
+
+    if [[ ! -x "$launcher" ]]; then
+        fail "$module_name: $launcher_name not found"
+    fi
+
+    log "Running $launcher_name with $np processes..."
+    local rc=0
+    mpiexec -np "$np" "$launcher" "$@" >"$output_log" 2>&1 || rc=$?
+
+    # osu_latency_mp uses fork() which causes system openmpi (ORTE) to
+    # abort the entire mpiexec. Tolerate this known failure rather than
+    # failing the whole test suite.
+    if [[ $rc -ne 0 ]]; then
+        if grep -q 'exiting improperly' "$output_log"; then
+            log "WARNING: $launcher_name exited abnormally (likely osu_latency_mp fork issue)"
+            grep 'exiting improperly' "$output_log" | sed 's/^/    /'
+        else
+            cat "$output_log"
+            rm -f "$output_log"
+            fail "$module_name: $launcher_name (exit code $rc)"
+        fi
+    elif grep -q 'exited with failure:' "$output_log"; then
+        grep -A 100 'exited with failure:' "$output_log"
+        rm -f "$output_log"
+        fail "$module_name: $launcher_name reported test failures"
+    fi
+
+    if [[ $VERBOSE -eq 1 ]]; then
+        cat "$output_log"
+    fi
+    rm -f "$output_log"
+    pass "$module_name: $launcher_name"
+}
+
+# ------------------------------------------------------------------------------
+# Test one MPI module
+# ------------------------------------------------------------------------------
+
+test_mpi_module() {
+    local module_name="$1"
+
+    log "========================================"
+    log "Testing MPI module: $module_name"
+    log "========================================"
+    echo ""
+
+    # Load module — if it refuses to load (e.g. mvapich on a non-GPU
+    # machine), skip this module rather than failing the whole test suite.
+    if ! module load "$module_name" 2>&1; then
+        log "Skipping $module_name: module failed to load"
+        echo ""
+        return
+    fi
+    verbose_log "Loaded module $module_name"
+
+    # Verify mpicc is available
+    if ! command -v mpicc >/dev/null 2>&1; then
+        fail "$module_name: mpicc not found after loading module"
+    fi
+    pass "$module_name: mpicc available"
+    verbose_log "mpicc location: $(command -v mpicc)"
+
+    # Verify mpiexec is available
+    if ! command -v mpiexec >/dev/null 2>&1; then
+        fail "$module_name: mpiexec not found after loading module"
+    fi
+    pass "$module_name: mpiexec available"
+
+    # Build OMB
+    build_omb "$module_name"
+
+    # Run startup tests (standalone binaries, 1 process each)
+    log "Running startup tests..."
+    run_omb_test "$module_name" "$OMB_SRC/c/mpi/startup/osu_hello" 1
+    run_omb_test "$module_name" "$OMB_SRC/c/mpi/startup/osu_init" 1
+
+    # Run single-host point-to-point benchmarks via launcher (2 processes).
+    # The congestion suite requires multiple nodes so is excluded here.
+    run_omb_launcher "$module_name" "$OMB_SRC/c/mpi/pt2pt/omb_pt2pt" 2 \
+        -- s:standard s:persistent
+
+    # Run collective benchmarks via launcher (nproc processes)
+    run_omb_launcher "$module_name" "$OMB_SRC/c/mpi/collective/omb_coll" "$(nproc)"
+
+    # Unload module
+    module unload "$module_name" 2>/dev/null || true
+    echo ""
+}
+
+# ------------------------------------------------------------------------------
+# Main
+# ------------------------------------------------------------------------------
+
+main() {
+    log "=========================================================="
+    log "MPI Implementation Test Suite (OSU Micro-Benchmarks)"
+    log "=========================================================="
+    echo ""
+
+    # MPI tests must not run as root
+    if [[ $(id -u) -eq 0 ]]; then
+        echo "ERROR: This test must be run as a regular user, not root"
+        exit 1
+    fi
+
+    # Check OMB source is present
+    if [[ ! -f "$OMB_SRC/configure" ]]; then
+        echo "ERROR: OMB source not found at $OMB_SRC"
+        exit 1
+    fi
+
+    # Discover MPI modules. Sort mvapich modules to the end of the list
+    # so that the well-tested MPI libraries are validated first.
+    local modules
+    readarray -t modules < <(ml -t spider mpi/ 2>&1 | grep '^mpi/' | sort | \
+        awk '
+            /mvapich/ { deferred[++n] = $0; next }
+            { print }
+            END { for (i = 1; i <= n; i++) print deferred[i] }
+        ')
+
+{% raw %}
+    if [[ ${#modules[@]} -eq 0 ]]; then
+        echo "ERROR: No MPI modules found"
+        exit 1
+    fi
+
+    log "Found ${#modules[@]} MPI module(s): ${modules[*]}"
+{% endraw %}
+    echo ""
+
+    # Test each module
+    for module in "${modules[@]}"; do
+        test_mpi_module "$module"
+    done
+
+    # Clean up final build
+    clean_omb
+
+    # Summary
+    echo ""
+    log "=========================================================="
+    log "Test Summary"
+    log "=========================================================="
+    log "  Passed:  $PASSED"
+    log "=========================================================="
+    exit 0
+}
+
+main "$@"

--- a/templates/test-mpi-omb.sh.j2
+++ b/templates/test-mpi-omb.sh.j2
@@ -13,6 +13,7 @@
 set -euo pipefail
 
 VERBOSE=0
+ENABLE_CUDA=0
 PASSED=0
 
 OMB_SRC="{{ __hpc_azure_omb_dir }}"
@@ -47,6 +48,7 @@ Usage: $(basename "$0") [OPTIONS]
 Build and run OSU Micro-Benchmarks against all installed MPI libraries
 
 OPTIONS:
+  -g    Enable CUDA/GPU support (build with --enable-cuda)
   -v    Verbose output
   -h    Show this help message
 
@@ -58,13 +60,21 @@ EOF
 # Parse Arguments
 # ------------------------------------------------------------------------------
 
-while getopts "vh" opt; do
+while getopts "gvh" opt; do
     case $opt in
+        g) ENABLE_CUDA=1 ;;
         v) VERBOSE=1 ;;
         h) usage ;;
         *) usage ;;
     esac
 done
+
+if [[ $ENABLE_CUDA -eq 1 ]]; then
+    if ! nvidia-smi -L >/dev/null 2>&1; then
+        echo "ERROR: -g requires NVidia GPUs but none were detected"
+        exit 1
+    fi
+fi
 
 # ------------------------------------------------------------------------------
 # Build OMB for a given MPI module
@@ -75,11 +85,23 @@ build_omb() {
     local build_log
     build_log=$(mktemp /tmp/omb-build-XXXXXX.log)
 
-    log "Building OMB for $module_name in $OMB_SRC"
+    local cuda_flags=""
+    if [[ $ENABLE_CUDA -eq 1 ]]; then
+{% if hpc_build_mpi_w_nvidia_gpu_support %}
+        cuda_flags="--enable-cuda --with-cuda={{ __hpc_cuda_path }}"
+        log "Building OMB for $module_name in $OMB_SRC (CUDA enabled)"
+{% else %}
+        echo "ERROR: CUDA/GPU support was not enabled when MPI libraries were built"
+        exit 1
+{% endif %}
+    else
+        log "Building OMB for $module_name in $OMB_SRC"
+    fi
 
     clean_omb
 
-    if ! (cd "$OMB_SRC" && ./configure CC=mpicc CXX=mpicxx) >"$build_log" 2>&1; then
+    # shellcheck disable=SC2086
+    if ! (cd "$OMB_SRC" && ./configure CC=mpicc CXX=mpicxx $cuda_flags) >"$build_log" 2>&1; then
         cat "$build_log"
         rm -f "$build_log"
         fail "OMB configure failed for $module_name"

--- a/templates/test-mpi-omb.sh.j2
+++ b/templates/test-mpi-omb.sh.j2
@@ -88,8 +88,8 @@ build_omb() {
     local cuda_flags=""
     if [[ $ENABLE_CUDA -eq 1 ]]; then
 {% if hpc_build_mpi_w_nvidia_gpu_support %}
-        cuda_flags="--enable-cuda --with-cuda={{ __hpc_cuda_path }}"
-        log "Building OMB for $module_name in $OMB_SRC (CUDA enabled)"
+        cuda_flags="--enable-cuda --with-cuda={{ __hpc_cuda_path }} --enable-ncclomb"
+        log "Building OMB for $module_name in $OMB_SRC (CUDA/NCCL enabled)"
 {% else %}
         echo "ERROR: CUDA/GPU support was not enabled when MPI libraries were built"
         exit 1
@@ -99,6 +99,23 @@ build_omb() {
     fi
 
     clean_omb
+
+    # Workarounds for OMB 8.0b2 bugs (patch sources then regenerate).
+    if [[ $ENABLE_CUDA -eq 1 ]]; then
+        # xccl Makefile.am files are missing omb_color.c from UTILITIES
+        for mkfile in "$OMB_SRC"/c/xccl/*/Makefile.am; do
+            if ! grep -q 'omb_color' "$mkfile"; then
+                sed -i '/osu_util_papi\.c \.\.\/\.\.\/util\/osu_util_papi\.h \\/a\    ../../util/omb_color.c ../../util/omb_color.h \\' "$mkfile"
+            fi
+        done
+
+        # configure.ac uses cudaFree to detect libcudart, but cudaFree is
+        # resolved via the rpath to libcuda so AC_SEARCH_LIBS doesn't add
+        # -lcudart. Use cudaStreamSynchronize which is only in libcudart.
+        sed -i 's/cudaFree/cudaStreamSynchronize/' "$OMB_SRC/configure.ac"
+
+        (cd "$OMB_SRC" && autoreconf -fi) >"$build_log" 2>&1
+    fi
 
     # shellcheck disable=SC2086
     if ! (cd "$OMB_SRC" && ./configure CC=mpicc CXX=mpicxx $cuda_flags) >"$build_log" 2>&1; then
@@ -249,6 +266,30 @@ test_mpi_module() {
 
     # Run collective benchmarks via launcher (nproc processes)
     run_omb_launcher "$module_name" "$OMB_SRC/c/mpi/collective/omb_coll" "$(nproc)"
+
+    # NCCL tests (only when -g is passed)
+    if [[ $ENABLE_CUDA -eq 1 ]]; then
+        local gpu_count
+        gpu_count=$(nvidia-smi -L 2>/dev/null | grep -c '^GPU')
+
+        # NCCL requires one GPU per rank and at least 2 ranks
+        if [[ $gpu_count -lt 2 ]]; then
+            log "Skipping NCCL tests: requires at least 2 GPUs ($gpu_count found)"
+        else
+            log "Running NCCL pt2pt benchmarks..."
+            run_omb_test "$module_name" "$OMB_SRC/c/xccl/pt2pt/osu_xccl_latency" 2
+            run_omb_test "$module_name" "$OMB_SRC/c/xccl/pt2pt/osu_xccl_bw" 2
+            run_omb_test "$module_name" "$OMB_SRC/c/xccl/pt2pt/osu_xccl_bibw" 2
+
+            log "Running NCCL collective benchmarks ($gpu_count GPUs)..."
+            run_omb_test "$module_name" "$OMB_SRC/c/xccl/collective/osu_xccl_allreduce" "$gpu_count"
+            run_omb_test "$module_name" "$OMB_SRC/c/xccl/collective/osu_xccl_allgather" "$gpu_count"
+            run_omb_test "$module_name" "$OMB_SRC/c/xccl/collective/osu_xccl_bcast" "$gpu_count"
+            run_omb_test "$module_name" "$OMB_SRC/c/xccl/collective/osu_xccl_reduce" "$gpu_count"
+            run_omb_test "$module_name" "$OMB_SRC/c/xccl/collective/osu_xccl_reduce_scatter" "$gpu_count"
+            run_omb_test "$module_name" "$OMB_SRC/c/xccl/collective/osu_xccl_alltoall" "$gpu_count"
+        fi
+    fi
 
     # Unload module
     module unload "$module_name" 2>/dev/null || true

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -16,6 +16,7 @@
     hpc_build_mpi_w_nvidia_gpu_support: false
     hpc_install_mvapich: false
     hpc_install_mpifileutils: false
+    hpc_install_mpi_tests: false
     hpc_enable_eus_repo: false
     hpc_install_moneo: false
     hpc_install_nvidia_container_toolkit: false

--- a/tests/tests_include_vars_from_parent.yml
+++ b/tests/tests_include_vars_from_parent.yml
@@ -61,6 +61,7 @@
             hpc_build_mpi_w_nvidia_gpu_support: false
             hpc_install_mvapich: false
             hpc_install_mpifileutils: false
+            hpc_install_mpi_tests: false
             hpc_enable_eus_repo: false
             hpc_install_moneo: false
             hpc_install_nvidia_container_toolkit: false

--- a/tests/tests_skip_toolkit.yml
+++ b/tests/tests_skip_toolkit.yml
@@ -16,6 +16,7 @@
     hpc_build_mpi_w_nvidia_gpu_support: false
     hpc_install_mvapich: false
     hpc_install_mpifileutils: false
+    hpc_install_mpi_tests: false
     hpc_reboot_ok: true
     hpc_enable_eus_repo: false
     hpc_install_nvidia_fabric_manager: false

--- a/vars/RedHat_9.yml
+++ b/vars/RedHat_9.yml
@@ -64,6 +64,11 @@ __hpc_mvapich_info:
   version: 4.0
   sha256: c532f7bdd5cca71f78c12e0885c492f6e276e283711806c84d0b0f80bb3e3b74
   url: https://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich-4.0.tar.gz
+__hpc_omb_info:
+  name: osu-micro-benchmarks
+  version: 8.0b2
+  sha256: 2ea96f0d569b012e70eb5cf8d1025890a228e0dfdb3e84d202c3cf53ee34f1b7
+  url: https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-8.0b2.tar.gz
 __hpc_mpifileutils_info:
   name: mpifileutils
   version: 0.12

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -110,6 +110,7 @@ __hpc_azure_tests_dir: "{{ __hpc_azure_resource_dir }}/tests"
 __hpc_azure_moneo_dir: "{{ __hpc_azure_tools_dir }}/Moneo"
 __hpc_mpifileutils_install_dir: "{{ __hpc_azure_resource_dir }}/mpifileutils"
 __hpc_mvapich_install_dir: "{{ __hpc_install_prefix }}/mvapich"
+__hpc_azure_omb_dir: "{{ __hpc_azure_tests_dir }}/osu-micro-benchmarks"
 
 # location for runtime selected azure resources
 __hpc_azure_runtime_dir: /var/hpc/azure

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -73,11 +73,12 @@ __hpc_gdrcopy_build_dependencies:
 __hpc_pmix_build_dependencies:
   - hwloc-devel
   - libevent-devel
-__hpc_openmpi_build_dependencies:
-  - binutils-devel
+__hpc_mpi_packages:
   - autoconf
   - automake
   - libtool
+__hpc_openmpi_build_dependencies:
+  - binutils-devel
 __hpc_versionlock_path: /etc/dnf/plugins/versionlock.list
 __hpc_kernel_versionlock_rpms:
   - kernel


### PR DESCRIPTION
This series:
- adds a new MPI library test script installed into /opt/hpc/azure/tests
- adds the source tree for the OSU (Ohio State University) MPI test infrastructure under /opt/hpc/azure/tests/osu-micro-benchmarks
- iterates over all the installed MPI environments, building the tests and running them on a single host
- tests both CPU based MPI as well as CUDA/GPU based MPI
- runs installation, point-to-point and collective tests
- When multiple GPUs are present in the system, it also builds and runs GPU based point-to-point and collective tests
- currently only runs on a single host

This series is built on top of the mpi-updates branch posted in PR #134 and so will require that PR to be merged first.

```
$ ./test-mpi-omb.sh -g
[2026-05-20 23:35:25] ==========================================================
[2026-05-20 23:35:25] MPI Implementation Test Suite (OSU Micro-Benchmarks)
[2026-05-20 23:35:25] ==========================================================

[2026-05-20 23:35:25] Found 5 MPI module(s): mpi/hpcx-2.24.1 mpi/hpcx-2.24.1-pmix-4.2.9 mpi/openmpi-5.0.8-cuda12-gpu mpi/openmpi-x86_64 mpi/mvapich-4.0

[2026-05-20 23:35:25] ========================================
[2026-05-20 23:35:25] Testing MPI module: mpi/hpcx-2.24.1
[2026-05-20 23:35:25] ========================================

[PASS] mpi/hpcx-2.24.1: mpicc available
[PASS] mpi/hpcx-2.24.1: mpiexec available
[2026-05-20 23:35:26] Building OMB for mpi/hpcx-2.24.1 in /opt/hpc/azure/tests/osu-micro-benchmarks (CUDA/NCCL enabled)
[PASS] mpi/hpcx-2.24.1: OMB build succeeded
[2026-05-20 23:35:59] Running startup tests...
[PASS] mpi/hpcx-2.24.1: osu_hello
[PASS] mpi/hpcx-2.24.1: osu_init
[2026-05-20 23:36:00] Running omb_pt2pt with 2 processes...
[PASS] mpi/hpcx-2.24.1: omb_pt2pt
[2026-05-20 23:36:04] Running omb_coll with 8 processes...
[PASS] mpi/hpcx-2.24.1: omb_coll
[2026-05-20 23:36:35] Skipping NCCL tests: requires at least 2 GPUs (1 found)

[2026-05-20 23:36:36] ========================================
[2026-05-20 23:36:36] Testing MPI module: mpi/hpcx-2.24.1-pmix-4.2.9
[2026-05-20 23:36:36] ========================================
.....

[2026-05-20 23:42:07] ==========================================================
[2026-05-20 23:42:07] Test Summary
[2026-05-20 23:42:07] ==========================================================
[2026-05-20 23:42:07]   Passed:  35
[2026-05-20 23:42:07] ==========================================================
```
The tests will not run if GPU testing is requested and there are no GPUs in the system:

```
$ ./test-mpi-omb.sh -g
ERROR: -g requires NVidia GPUs but none were detected
$

```
If the MPI module doesn't load (e.g. because there are no GPUs in the system) then it will gracefully handle the load failure:

```
$ ./test-mpi-omb.sh
....
[2026-05-21 01:16:31] ========================================
[2026-05-21 01:16:31] Testing MPI module: mpi/mvapich-4.0
[2026-05-21 01:16:31] ========================================

Error: MVAPICH 4.0 was built with CUDA/UCX support and requires NVidia GPUs. This machine has no GPUs. Use a different MPI module (e.g. hpcx or openmpi). 
[2026-05-21 01:16:32] Skipping mpi/mvapich-4.0: module failed to load


[2026-05-21 01:16:32] ==========================================================
[2026-05-21 01:16:32] Test Summary
[2026-05-21 01:16:32] ==========================================================
[2026-05-21 01:16:32]   Passed:  28
[2026-05-21 01:16:32] ==========================================================
$

```
Issue Tracker Tickets (Jira or BZ if any): https://redhat.atlassian.net/browse/RHELHPC-118


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `hpc_install_mpi_tests` flag to control whether OSU Micro-Benchmarks are installed for MPI performance testing, including GPU/CUDA validation when available.
  * Introduced an enhanced MPI benchmark harness that discovers MPI modules and runs startup, point-to-point, and collective tests, with optional NCCL GPU benchmarks.

* **Documentation**
  * Documented `hpc_install_mpi_tests` in the README, including default behavior.

* **Chores / Tests**
  * Refined MPI build dependency handling and updated test playbooks to explicitly disable MPI test installation where appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->